### PR TITLE
Update puppet/extlib dependency range

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet/extlib",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
puppet/extlib had a major version bump to 2.0.0 on 2017-10-11. The
major version bump appear to be primarily due to updates to required
versions.

Fixes #7

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>